### PR TITLE
feat(issue-4): improve help of `--strict`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,11 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "libc"
 version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +563,7 @@ dependencies = [
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "fallible-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "simple-error 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -613,6 +619,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum jobserver 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b1d42ef453b30b7387e113da1c83ab1605d90c5b4e0eb8e96d016ed3b8c160"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
+"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum libgit2-sys 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a30f8637eb59616ee3b8a00f6adff781ee4ddd8343a615b8238de756060cc1b3"
 "checksum libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ askama = "0.8"
 chrono = "0.4.9"
 log = "0.4.8"
 stderrlog = "0.4.3"
+lazy_static = "1.4.0"
 
 [dependencies.git2]
 version = "0.10"

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use semver::Version;
 use simple_error::SimpleError;
 use structopt::StructOpt;
 use log::{warn, error};
+use lazy_static::lazy_static;
 
 use crate::bumping::{Bump, BumpType};
 use crate::changelog::ChangeLog;
@@ -13,6 +14,13 @@ use crate::changelog::ChangeLog;
 mod bumping;
 mod repo;
 mod changelog;
+
+lazy_static! {
+    static ref STRICT_HELP: String = format!(r#"Quit with an error if non-conventional commit messages are found.
+
+Default behaviour is to simply print a warning. Conventional messages start with
+one of the following types: {}."#, bumping::OTHER_TYPES.join(", "));
+}
 
 /// Detect version bump based on Conventional Commits
 ///
@@ -56,11 +64,7 @@ struct Config {
     #[structopt(long, short)]
     overwrite: bool,
 
-    /// Quit with an error if non-conventional commit messages are found.
-    ///
-    /// Default behaviour is to simply print a warning. Allowed values are those recommended
-    /// by https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional.
-    #[structopt(long)]
+    #[structopt(long, help = &STRICT_HELP)]
     strict: bool,
 
     /// Verbose mode (-v, -vv, -vvv, etc)


### PR DESCRIPTION
Print in the help messages what "types" of commit messages are
supported.

We believe this is better than asking the user to go check a
website.