### PR TITLE
Features/release script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,7 +557,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "what-bump"
-version = "1.0.2"
+version = "0.0.0-UNRELEASED"
 dependencies = [
  "askama 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["albx79 <otrebla79>"]
 edition = "2018"
 name = "what-bump"
-version = "1.0.2"
+version = "0.0.0-UNRELEASED"
 license-file = "LICENSE"
 description = "Detect required version bump based on conventional commit messages"
 repository = "https://github.com/sky-uk/what-bump"


### PR DESCRIPTION
Prototype release script, the idea is to be able to run it in CI.

This will use `git`, `sed` and `what-bump` to determine the previous release, calculate a new version, update the Cargo manifest, publish to crates.io, and restore the "unreleased" version number. It will do everything on the current branch (which ideally should be `develop`) in order to preserve a linear history.