### PR TITLE
build: hopefully next release will be easier

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,8 +50,6 @@ workflows:
   build:
     jobs:
       - build
-  release:
-    jobs:
       - release:
           requires:
             - build


### PR DESCRIPTION
added a "release" CI job that is triggered on release tags. So Ideally when I run the release script locally, it will trigger a release build on circle-ci.