### PR TITLE
fix(issues/16): use git's revwalk instead of my custom code

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,4 @@
+
+pub trait ToSimpleError {
+    fn to_simple_error(&self) -> simple_error::SimpleError;
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use crate::changelog::ChangeLog;
 mod bumping;
 mod repo;
 mod changelog;
+mod error;
 
 lazy_static! {
     static ref STRICT_HELP: String = format!(r#"Quit with an error if non-conventional commit messages are found.


### PR DESCRIPTION
removed ugly custom code for walking the commit history.

Replaced it with git's standard Revwalk, which supports merge commits properly.

Fixes #16 .