### PR TITLE
feat: accept non-semver numbers for changelog

### DIFF
--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -45,7 +45,7 @@ impl TemplateType {
 
 /// Contains all data needed to write the changelog
 pub struct ChangeLog {
-    pub version: Version,
+    pub version: String,
     pub date: NaiveDate,
     pub fixes: Vec<LogEntry>,
     pub features: Vec<LogEntry>,
@@ -57,7 +57,7 @@ impl Default for ChangeLog {
     fn default() -> Self {
         let today = Local::today();
         ChangeLog {
-            version: Version::parse("0.0.0").unwrap(),
+            version: "0.0.0".to_owned(),
             date: NaiveDate::from_yo(today.year(), today.ordinal()),
             fixes: vec![],
             features: vec![],

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,13 @@ struct Config {
     #[structopt(long, short)]
     from: Option<Version>,
 
+    /// New version of your software (for changelog)
+    ///
+    /// Manually specify the new version of your software. Useful if you're just generating
+    /// the changelog.
+    #[structopt(long, short, requires = "changelog")]
+    new_version: Option<String>,
+
     /// Location of the GIT repo.
     #[structopt(long, short, default_value = "./")]
     path: repo::ConventionalRepo,
@@ -150,7 +157,7 @@ fn what_bump(config: Config) -> Result<(), Box<dyn Error>> {
 
     if let Some(cl_path) = config.changelog {
         let mut changelog = ChangeLog::new(config.path.commits_up_to(&up_to_revision)?);
-        if let Some(new_version) = new_version {
+        if let Some(new_version) = config.new_version.or(new_version.map(|v| v.to_string())) {
             changelog.version = new_version;
         }
         changelog.save(&cl_path, config.overwrite, TemplateType::from_cli(config.template, config.template_id))?;


### PR DESCRIPTION
Add a new commandline option, `--new-version`, that can be specified when generating the changelog, and overrides the calculated version with a custom string (that doesn't have to be a Semantic Version).